### PR TITLE
feat: Add feature to automatically set execution permissions for the modified executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ This effectively prevents GDB from debugging the binary by making it "unrecogniz
 # Run the programm by passing the binary to modify
 gpoise <binaryname>
 
-#Make the modified binary executable
-chmod +x <binaryname>_modified
+# This will create the binary <filename>_modified
 
 #For help use:
 gdpoise -h

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ INSTALL_DIR="$HOME/.local/bin"
 mkdir -p "$INSTALL_DIR"
 
 echo "Compiling the program..."
-gcc -g -o gdpoise gdpoise.c
+gcc -g -o gdpoise src/gdpoise.c
 
 if [[ $? -ne 0 ]]; then
   echo "Compilation failed!"

--- a/src/gdpoise.c
+++ b/src/gdpoise.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 int read_elf(char *filename) {
   FILE *fptr = fopen(filename, "rb");
@@ -103,6 +104,9 @@ int write_elf(char *input_file, char *output_file, uint16_t new_shnum,
   }
 
   fclose(outfile);
+  printf("Setting execution permissions...\n");
+  chmod(output_file,
+        S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
   free(file_data);
   return 0;
 }


### PR DESCRIPTION
gdpoise now automatically sets the execution bits of the generated binary. In addition I also updated the install script and updated the readme